### PR TITLE
python3 compatibility

### DIFF
--- a/openflexure_microscope/keyboard_control.py
+++ b/openflexure_microscope/keyboard_control.py
@@ -15,7 +15,7 @@ Options:
       --output=<filepath>   Set output directory/filename [default: ~/Desktop/images]
       -h --help             Show this screen.
 """
-
+from __future__ import print_function
 import io
 import sys
 import os
@@ -23,6 +23,7 @@ import time
 import argparse
 import numpy as np
 import picamera
+from builtins import input
 from readchar import readchar, readkey
 from openflexure_stage import OpenFlexureStage
 from .microscope import load_microscope

--- a/openflexure_microscope/keyboard_control.py
+++ b/openflexure_microscope/keyboard_control.py
@@ -25,7 +25,7 @@ import numpy as np
 import picamera
 from readchar import readchar, readkey
 from openflexure_stage import OpenFlexureStage
-from microscope import load_microscope
+from .microscope import load_microscope
 
 def validate_filepath(filepath):
     """Check the filepath is valid, creating dirs if needed
@@ -196,17 +196,17 @@ def image_stack(ms, raw=False):
     """Acquire a stack of images, prompting the operator for parameters"""
     ms.camera.stop_preview()
     try:
-        output_dir = os.path.expanduser(raw_input("Output directory: "))
+        output_dir = os.path.expanduser(input("Output directory: "))
         os.mkdir(output_dir)
-        step_size = [int(raw_input("{} step size: ".format(ax))) for ax in ['X', 'Y', 'Z']]
-        n_steps = int(raw_input("Number of images: "))
+        step_size = [int(input("{} step size: ".format(ax))) for ax in ['X', 'Y', 'Z']]
+        n_steps = int(input("Number of images: "))
         ms.camera.start_preview()
         ms.camera.annotate_text = ""
         ms.acquire_image_stack(step_size, n_steps, output_dir, raw=raw)
         ms.camera.annotate_text = "Acquired {} images to {}".format(n_steps, output_dir)
         time.sleep(1)
     except Exception as e:
-        print "Error: {}".format(e)
+        print("Error: {}".format(e))
 
 
 def control_parameters_from_microscope(microscope):
@@ -227,7 +227,7 @@ def control_parameters_from_microscope(microscope):
             InteractiveCameraParameter(cam, "brightness", np.linspace(0,100,11), setter_conversion=int),
             InteractiveCameraParameter(cam, "contrast", np.linspace(-50,50,11), setter_conversion=int),
             InteractiveCameraParameter(microscope, "zoom", 2**np.linspace(0,4,9)),
-            ReadOnlyObjectParameter(cam, "awb_gains", filter_function=lambda (a, b): [float(a), float(b)]),
+            ReadOnlyObjectParameter(cam, "awb_gains", filter_function=lambda a_b: [float(a_b[0]), float(a_b[1])]),
             ReadOnlyObjectParameter(stage, "position", filter_function=str),
             ]
 
@@ -267,7 +267,7 @@ def control_microscope_with_keyboard(output="./images", dummy_stage=False, setti
             c = readkey()
             if c == 'x': #quit
                 break
-            elif c in move_keys.keys():
+            elif c in list(move_keys.keys()):
                 # move the stage with quake-style keys
                 stage.move_rel( np.array(move_keys[c]) * step_param.value)
             elif c in ['r', 'f']:
@@ -305,7 +305,7 @@ def control_microscope_with_keyboard(output="./images", dummy_stage=False, setti
                 camera.annotate_text=""
             elif c == "k":
                 camera.stop_preview()
-                new_filepath = raw_input("The new output location can be a directory or \n"
+                new_filepath = input("The new output location can be a directory or \n"
                                          "a filepath.  Directories will be created if they \n"
                                          "don't exist, filenames must contain '%d' and '.jp'.\n"
                                          "New filepath: ")

--- a/openflexure_microscope/microscope.py
+++ b/openflexure_microscope/microscope.py
@@ -204,7 +204,7 @@ class Microscope(object):
     def settings_dict(self):
         """Return all the relevant settings as a dictionary."""
         settings = {}
-        for k in picamera_later_settings.keys() + picamera_init_settings.keys():
+        for k in list(picamera_later_settings.keys()) + list(picamera_init_settings.keys()):
             settings[k] = getattr(self.camera, k)
         return settings
 

--- a/openflexure_microscope/utilities/recalibrate.py
+++ b/openflexure_microscope/utilities/recalibrate.py
@@ -42,7 +42,7 @@ def lens_shading_correction_from_rgb(rgb_array, binsize=64):
         # horizontally, but not vertically.
         for dx in np.arange(box) - box//2:
             for dy in np.arange(box) - box//2:
-                ls_channel[:,:] += padded_image_channel[binsize/2+dx::binsize,binsize/2+dy::binsize]
+                ls_channel[:,:] += padded_image_channel[binsize//2+dx::binsize,binsize//2+dy::binsize]
         ls_channel /= box**2
         # Everything is normalised relative to the centre value.  I follow 6by9's
         # example and average the central 64 pixels in each channel.

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(name = 'openflexure_microscope',
           ],
       install_requires = [
           'pyserial',
+          'future',
           'openflexure_stage',
           'readchar',
           'numpy',


### PR DESCRIPTION
Several changes to run scripts on python3.

NB: changes were also required in picamera/lens_shading and
openflexure_stage so python3 version of these must be installed for this
to work.